### PR TITLE
Add the baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ url: http://manjaro.github.io
 # (http://yourusername.github.io/repository-name)
 # and NOT your User repository (http://yourusername.github.io)
 # then add in the baseurl here, like this: "/repository-name"
-baseurl: ""
+baseurl: "http://manjaro.github.io"
 
 #
 # !! You don't need to change any of the configuration flags below !!


### PR DESCRIPTION
This removes even more feed errors

http://jekyllrb.com/docs/github-pages/#project-page-url-structure

Also I think this fixes #3 according to the docs the final error "Self reference doesn't match document location" is probably just a validator issue. http://validator.w3.org/feed/docs/warning/SelfDoesntMatchLocation.html